### PR TITLE
Bump chart version and publish Helm Chart 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,21 +25,17 @@ jobs:
     - name: Bump Helm Chart Version
       run: |
         #!/bin/bash
-        set -x
         python3 -m pip install pybump
         charts=$(ls -d charts/*/ | awk -F/ '{print $2}')
-        echo $charts
         for chart in $charts;
         do
-          echo $chart
           chart_ver=$(yq '.version' charts/$chart/Chart.yaml);
           chart_changes="$(git diff --name-only HEAD $chart-$chart_ver -- charts/$chart)";
           if [ ! -z "$chart_changes" ];
           then
             pybump bump --file charts/$chart/Chart.yaml --level patch --quiet
             new_version=$(yq '.version' charts/$chart/Chart.yaml )
-            echo $new_version
-            echo "git push"
+            echo $chart-$new_version
             git add charts/$chart/Chart.yaml
             git commit -m "Bump $chart version $new_version"
             git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [ master ]
+#  push:
+#    branches: [ master ]
   workflow_dispatch:
 
 jobs:
@@ -13,6 +13,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
           fetch-depth: 0
+          token: "${{ secrets.GITHUB_TOKEN }}"
     - name: Configure Git
       run: |
         git config user.name "$GITHUB_ACTOR"
@@ -20,7 +21,30 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v1
       with:
-        version: v3.4.0
+        version: v3.9.3
+    - name: Bump Helm Chart Version
+      run: |
+        #!/bin/bash
+        set -x
+        python3 -m pip install pybump
+        charts=$(ls -d charts/*/ | awk -F/ '{print $2}')
+        echo $charts
+        for chart in $charts;
+        do
+          echo $chart
+          chart_ver=$(yq '.version' charts/$chart/Chart.yaml);
+          chart_changes="$(git diff --name-only HEAD $chart-$chart_ver -- charts/$chart)";
+          if [ ! -z "$chart_changes" ];
+          then
+            pybump bump --file charts/$chart/Chart.yaml --level patch --quiet
+            new_version=$(yq '.version' charts/$chart/Chart.yaml )
+            echo $new_version
+            echo "git push"
+            git add charts/$chart/Chart.yaml
+            git commit -m "Bump $chart version $new_version"
+            git push
+          fi
+        done
     - name: Helm Chart Releaser
       uses: helm/chart-releaser-action@v1.2.1
       env:

--- a/charts/odd-collector/Chart.yaml
+++ b/charts/odd-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: odd-collector
+appVersion: latest
 description: A Helm chart for any odd-collector compatible deployments
+name: odd-collector
 type: application
 version: 0.1.3
-appVersion: 0.1.1


### PR DESCRIPTION
Added new functions
- Disabled automatically workflow execution
- Find changes in each chart and compare them with the chartname-version git tag, if `git diff` return some result, bump the chart version, push changes back to master and start old publish process
